### PR TITLE
Fix reading strings representing numbers in Update MTUserBase.cs

### DIFF
--- a/Common/Protocol/MTUserBase.cs
+++ b/Common/Protocol/MTUserBase.cs
@@ -861,9 +861,12 @@ namespace MetaQuotes.MT5WebAPI.Common.Protocol
     {
         public override ulong Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType == JsonTokenType.Number && reader.TryGetUInt64(out ulong value))
+            var tokType = reader.TokenType;
+            if (tokType == JsonTokenType.String)
             {
-                return value;
+                var tokStr = reader.GetString();
+                if ( ulong.TryParse(tokStr, out ulong value))
+                    return value;
             }
 
             throw new JsonException("Invalid JSON format for ulong.");


### PR DESCRIPTION
Read text representation of numbers as strings at the first place then convert to unsigned long integers respectively